### PR TITLE
Macros in match without code block

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Poly <alexhexan22@gmail.com>"]
 edition = "2018"
 
 documentation = "https://docs.rs/paris"
-homepage = "https://github.com/0x20F/logger"
-repository = "https://github.com/0x20F/logger"
+homepage = "https://github.com/0x20F/paris"
+repository = "https://github.com/0x20F/paris"
 readme = "README.md"
 
 keywords = ["log", "logger", "shell", "terminal", "cli"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paris"
-version = "1.4.1"
+version = "1.4.2"
 authors = ["Poly <alexhexan22@gmail.com>"]
 edition = "2018"
 
@@ -9,7 +9,7 @@ homepage = "https://github.com/0x20F/logger"
 repository = "https://github.com/0x20F/logger"
 readme = "README.md"
 
-keywords = ["log", "logger", "simple", "terminal", "cli"]
+keywords = ["log", "logger", "shell", "terminal", "cli"]
 categories = ["command-line-interface", "command-line-utilities"]
 
 description = "A simple logger for your CLI apps or other things you want in the terminal"

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 
 <p align="center">
-   <img alt="Build status badge" src="https://github.com/0x20F/logger/workflows/build/badge.svg"/>
+   <img alt="Build status badge" src="https://github.com/0x20F/paris/workflows/build/badge.svg"/>
    <img alt="Crates io badge" src="https://img.shields.io/crates/v/paris.svg"/>
    <a href="https://www.gnu.org/licenses/gpl-3.0"><img alt="License badge" src="https://img.shields.io/badge/License-GPLv3-blue.svg"/></a>
 </p>
 
 
 <p align="center">
-   <img src="https://github.com/0x20F/logger/blob/master/example/paris_example.gif"/>
+   <img src="https://github.com/0x20F/paris/blob/master/example/paris_example.gif"/>
 </p>
 
 

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -11,8 +11,7 @@
 #[macro_export]
 macro_rules! log {
     ($($arg:tt)*) => {
-        let message = format!($($arg)*);
-        $crate::output::stdout(message, "\n");
+        $crate::output::stdout(format!($($arg)*), "\n");
     }
 }
 
@@ -29,8 +28,7 @@ macro_rules! log {
 #[macro_export]
 macro_rules! info {
     ($($arg:tt)*) => {
-        let message = format!("<cyan><info></> {}", format!($($arg)*));
-        $crate::output::stdout(message, "\n");
+        $crate::output::stdout(format!("<cyan><info></> {}", format!($($arg)*)), "\n");
     }
 }
 
@@ -47,8 +45,7 @@ macro_rules! info {
 #[macro_export]
 macro_rules! error {
     ($($arg:tt)*) => {
-        let message = format!("<red><cross></> {}", format!($($arg)*));
-        $crate::output::stderr(message, "\n");
+        $crate::output::stderr(format!("<red><cross></> {}", format!($($arg)*)), "\n");
     }
 }
 
@@ -64,9 +61,8 @@ macro_rules! error {
 /// ```
 #[macro_export]
 macro_rules! warn {
-        ($($arg:tt)*) => {
-        let message = format!("<yellow><warn></> {}", format!($($arg)*));
-        $crate::output::stdout(message, "\n");
+    ($($arg:tt)*) => {
+        $crate::output::stdout(format!("<yellow><warn></> {}", format!($($arg)*)), "\n");
     }
 }
 
@@ -83,8 +79,7 @@ macro_rules! warn {
 #[macro_export]
 macro_rules! success {
     ($($arg:tt)*) => {
-        let message = format!("<green><tick></> {}", format!($($arg)*));
-        $crate::output::stdout(message, "\n");
+        $crate::output::stdout(format!("<green><tick></> {}", format!($($arg)*)), "\n");
     }
 }
 
@@ -102,5 +97,11 @@ mod tests {
         error!("This is going to <bright red>stderr</> {}", "WOOOO");
         warn!("This is a {} <yellow>BEWARE</>!", "warning");
         success!("{} went well, congrats!", "<bright green>Everything</>");
+
+
+        match "a" {
+            "a" => log!("It works inside a match as well!!! {}", "<bright blue>finally</>"),
+            _ => unreachable!()
+        }
     }
 }


### PR DESCRIPTION
## Fixes:
```rust
error[E0658]: `let` expressions in this position are experimental
   --> src\macros\mod.rs:14:9
    |
14  |         let message = format!($($arg)*);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
104 |             "a" => log!("It works inside a match as well!!! {}", "<bright blue>finally</>"),
    |                    ------------------------------------------------------------------------ in this macro invocation
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
```

## Explanation:
A 2 line macro would try to expand in a 1 line match arm, feature that allows that is experimental so it'll break.


## What
This fixes it so it works without having to enable the experimental feature, at the cost of a bit of macro readability.