### PR TITLE
Hardcodes cyan escape sequence in loading method

### DIFF
--- a/src/logger/mod.rs
+++ b/src/logger/mod.rs
@@ -198,7 +198,11 @@ impl Logger {
                     i = 0;
                 }
 
-                let message = format!("\r<cyan>{}</> {}", frames[i], &thread_message);
+                // This should call the formatter::colorize() method
+                // but we don't have access to self in this thread.
+                // Instead, just hardcode it as cyan (36)
+                let message = format!("\r\x1B[36m{} {}", frames[i], &thread_message);
+                
 
                 output::stdout(message, "");
                 io::stdout().flush().unwrap();


### PR DESCRIPTION
The `Logger::loading()` method was using a string that was meant to be formatted with `Formatter::colorize()` (I assume) but it wasn't be called. Because it was in a thread, you couldn't access `self` without some extra work, so this commit just hardcodes the escape sequence for cyan in the loading message.

This probably isn't the best solution, but it works for now.