### PR TITLE
Fix readme img to work outside of GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 
 <p align="center">
-   <img src="https://github.com/0x20F/paris/blob/master/example/paris_example.gif"/>
+   <img src="https://github.com/0x20F/paris/blob/master/example/paris_example.gif?raw=true"/>
 </p>
 
 <br/>


### PR DESCRIPTION
The current img url only works on GitHub. See https://crates.io/crates/paris or https://lib.rs/crates/paris.

<img src="https://user-images.githubusercontent.com/1940490/166114832-960d143d-c887-499b-af0c-bdea2b1d009a.png" width="40%"><img src="https://user-images.githubusercontent.com/1940490/166114834-ac3bed0f-e93c-42b2-b96b-9fd7a483ab6c.png" width="40%">

<br>

The new one will work outside of GitHub too.

<img src="https://user-images.githubusercontent.com/1940490/166114916-3304de88-3cc6-4c93-ae77-142a66b663e0.png" width="40%">
