### PR TITLE
Remove chrono as dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paris"
-version = "1.5.12"
+version = "1.5.13"
 authors = ["Poly <0x20fa@gmail.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,7 @@ exclude = [
 maintenance = { status = "passively-maintained" }
 
 
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-chrono = { version = "0.4", optional = true }
-
-
 [features]
-timestamps = ["chrono"]
+timestamps = []
 macros = []
 no_logger = []

--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ log.info("It's that simple!");
 ##### Timestamps 
 If you'd like timestamps with all your logs you'll
 have to enable the feature when adding the crate as a dependency. 
-
-Notice: This will also include `chrono` as a dependency.
 ```toml
 [dependencies]
 paris = { version = "1.5", features = ["timestamps"] }

--- a/src/timestamp/mod.rs
+++ b/src/timestamp/mod.rs
@@ -2,10 +2,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn now() -> String {
     let current = SystemTime::now();
-    let since_epoch = current.duration_since(UNIX_EPOCH).expect("Time went backwards");
+    let since_epoch = current
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards");
     let timestamp = since_epoch.as_secs();
 
-    let hours = (timestamp % 86400 ) / 3600;
+    let hours = (timestamp % 86400) / 3600;
     let minutes = (timestamp % 3600) / 60;
     let seconds = timestamp % 60;
 

--- a/src/timestamp/mod.rs
+++ b/src/timestamp/mod.rs
@@ -1,17 +1,23 @@
 extern crate chrono;
 
-use chrono::{Timelike, Utc};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn now() -> String {
-    let now = Utc::now();
-    let (is_pm, hour) = now.hour12();
+    let current = SystemTime::now();
+    let since_epoch = current.duration_since(UNIX_EPOCH).expect("Time went backwards");
+    let timestamp = since_epoch.as_secs();
+
+    let hours = (timestamp % 86400 ) / 3600;
+    let minutes = (timestamp % 3600) / 60;
+    let seconds = timestamp % 60;
+
+    let is_pm = hours > 12;
 
     let stamp = format!(
-        "<dimmed>{:02}:{:02}:{:02}.{:03} {}: </>",
-        hour,
-        now.minute(),
-        now.second(),
-        now.nanosecond() / 1_000_000,
+        "<dimmed>{:02}:{:02}:{:02} {}: </>",
+        hours,
+        minutes,
+        seconds,
         if is_pm { "PM" } else { "AM" }
     );
 

--- a/src/timestamp/mod.rs
+++ b/src/timestamp/mod.rs
@@ -1,5 +1,3 @@
-extern crate chrono;
-
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn now() -> String {


### PR DESCRIPTION
Remove chrono as a dependency since it isn't needed.
The timestamp feature provided by paris isn't very in depth anyway, and doesn't need to be.
That's not the main focus.

This replaces it with something simpler.

Closes #47